### PR TITLE
fix: accumulate errors

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,43 @@
+package api
+
+func Join(errs ...error) error {
+	n := 0
+	for _, err := range errs {
+		if err != nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	e := &joinError{
+		errs: make([]error, 0, n),
+	}
+	for _, err := range errs {
+		if err != nil {
+			e.errs = append(e.errs, err)
+		}
+	}
+	return e
+}
+
+type joinError struct {
+	errs []error
+}
+
+func (e *joinError) Error() string {
+	var b []byte
+	for i, err := range e.errs {
+		if i > 0 {
+			b = append(b, '\n')
+		}
+		b = append(b, err.Error()...)
+	}
+	return string(b)
+}
+
+// Unwrap is a slight deviation from go1.20, because we may have a legacy
+// errors.Is which doesn't have support for unwrapping multiple errors
+func (e *joinError) Unwrap() error {
+	return e.errs[0]
+}


### PR DESCRIPTION
Our current behavior is to run all requests and return first error. This behavior is unintentional and unexpected: we should either return all errors, or cancel execution upon first error.

In keeping with existing behavior, we will continue executing all requests, but instead return an aggregate of all errors. This commit backports `errors.Join` from go 1.20 to combine errors.