### PR TITLE
feat: add ability to limit number of records

### DIFF
--- a/cmd/aws-snapshot/main.go
+++ b/cmd/aws-snapshot/main.go
@@ -33,6 +33,7 @@ func loadManifest(filename string, dst *api.Manifest) error {
 func realMain() error {
 	var (
 		maxConcurrentRequests = flag.Int("max-concurrent-requests", 10, "Maximum concurrent requests")
+		maxRecords            = flag.Int("max-records", 0, "Maximum number of records emitted")
 		bufferSize            = flag.Int("buffer-size", 100, "Length of buffer for records")
 		manifestFile          = flag.String("manifest-file", "", "Manifest filename")
 		requestTimeout        = flag.String("request-timeout", "", "Timeout per request, default is no timeout")
@@ -75,6 +76,7 @@ func realMain() error {
 	runner := api.Runner{
 		Requests:              reqs,
 		MaxConcurrentRequests: *maxConcurrentRequests,
+		MaxRecords:            *maxRecords,
 		BufferSize:            *bufferSize,
 		Recorder: api.RecorderFunc(func(ctx context.Context, ch <-chan *api.Record) error {
 			for {

--- a/pkg/api/limit.go
+++ b/pkg/api/limit.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"sync/atomic"
+)
+
+type limitCh struct {
+	in    chan *Record
+	out   chan *Record
+	count atomic.Int64
+	limit int64
+}
+
+func (l *limitCh) In() chan<- *Record {
+	return l.in
+}
+
+func (l *limitCh) Out() <-chan *Record {
+	return l.out
+}
+
+func (l *limitCh) Close() {
+	close(l.in)
+}
+
+func (l *limitCh) run(cancel func()) {
+	defer close(l.out)
+	for {
+		v, ok := <-l.in
+		if !ok {
+			return
+		}
+		l.out <- v
+		if l.count.Add(1) == l.limit {
+			cancel()
+			return
+		}
+	}
+}
+
+func newLimitCh(bufferSize, limit int, cancel func()) *limitCh {
+	if limit == 0 {
+		ch := make(chan *Record, bufferSize)
+		return &limitCh{
+			in:  ch,
+			out: ch,
+		}
+	}
+
+	l := &limitCh{
+		in:    make(chan *Record, bufferSize),
+		out:   make(chan *Record, bufferSize),
+		limit: int64(limit),
+	}
+
+	go l.run(cancel)
+	return l
+}

--- a/pkg/api/limit_test.go
+++ b/pkg/api/limit_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestLimitCh(t *testing.T) {
+
+	var cancelled bool
+	ch := newLimitCh(100, 10, func() {
+		cancelled = true
+	})
+
+	for i := 0; i <= 100; i++ {
+		ch.In() <- &Record{}
+	}
+	ch.Close()
+
+	var records []*Record
+	for r := range ch.Out() {
+		records = append(records, r)
+	}
+
+	if !cancelled {
+		t.Error("cancel callback not invoked")
+	}
+
+	if len(records) != 10 {
+		t.Error("received wrong number of records")
+	}
+}


### PR DESCRIPTION
This allows callers to cap the number of records in a given run.

This would have been trivial had we picked an API that didn't pass around channels, but alas, mistakes were made. As is, we need to read off one channel, and write to another. Shutdown is done from the write end.